### PR TITLE
Enable publication of detected object messages from euclidean_cluster…

### DIFF
--- a/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/euclidean_cluster.param.yaml
+++ b/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/euclidean_cluster.param.yaml
@@ -1,4 +1,4 @@
-use_detected_objects: False  
+use_detected_objects: True  
 use_cluster: True
 use_box: True
 max_cloud_size: 55000


### PR DESCRIPTION
This PR enables publication of DetectedObject messages in the euclidean_cluster node from Autoware.Auto which are required as inputs to the tracking nodes. 

Supports: https://github.com/usdot-fhwa-stol/carma-platform/issues/1557

Tested by local integration testing