### PR TITLE
Fix/add detected objects transforms

### DIFF
--- a/AutowareAuto/src/common/autoware_auto_tf2/CMakeLists.txt
+++ b/AutowareAuto/src/common/autoware_auto_tf2/CMakeLists.txt
@@ -30,7 +30,7 @@ if(BUILD_TESTING)
   # Linters
   ament_lint_auto_find_test_dependencies()
   # Unit test
-  ament_add_gtest(test_tf2_autoware_auto_msgs test/test_tf2_autoware_auto_msgs.cpp)
+  ament_add_gtest(test_tf2_autoware_auto_msgs test/test_tf2_autoware_auto_msgs.cpp test/test_tf2_autoware_auto_msgs_extension.cpp)
   autoware_set_compile_options(test_tf2_autoware_auto_msgs)
   target_include_directories(test_tf2_autoware_auto_msgs PRIVATE "include")
   ament_target_dependencies(test_tf2_autoware_auto_msgs

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -14,6 +14,13 @@
 /// \file
 /// \brief This file includes common transform functionality for autoware_auto_msgs
 
+/**
+ * Copyright (C) 2021 LEIDOS.
+ * 
+ * Modifications
+ * - Add DetectedObjects to the set of supporte types
+ */ 
+
 #ifndef AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_HPP_
 #define AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_HPP_
 
@@ -24,17 +31,27 @@
 #include <autoware_auto_msgs/msg/bounding_box.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <autoware_auto_msgs/msg/quaternion32.hpp>
+#include <autoware_auto_msgs/msg/detected_objects.hpp>
+#include <autoware_auto_msgs/msg/detected_object.hpp>
+#include <autoware_auto_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_auto_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 #include <kdl/frames.hpp>
 #include <common/types.hpp>
 #include <string>
+#include <limits>
 
 
 using autoware::common::types::float32_t;
 using autoware::common::types::float64_t;
 using BoundingBoxArray = autoware_auto_msgs::msg::BoundingBoxArray;
 using BoundingBox = autoware_auto_msgs::msg::BoundingBox;
+using DetectedObject = autoware_auto_msgs::msg::DetectedObject;
+using DetectedObjects = autoware_auto_msgs::msg::DetectedObjects;
+using DetectedObjectKinematics = autoware_auto_msgs::msg::DetectedObjectKinematics;
+using Shape = autoware_auto_msgs::msg::Shape;
+
 
 namespace tf2
 {
@@ -193,6 +210,140 @@ void doTransform(
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
 }
+
+/********************/
+/** DetectedObject **/
+/********************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObject type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The DetectedObject message to transform.
+ * \param t_out The transformed DetectedObject message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const DetectedObject & t_in, DetectedObject & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in;
+  doTransform(t_in.orientation, t_out.orientation, transform);
+  doTransform(t_in.centroid, t_out.centroid, transform);
+  doTransform(t_in.corners[0], t_out.corners[0], transform);
+  doTransform(t_in.corners[1], t_out.corners[1], transform);
+  doTransform(t_in.corners[2], t_out.corners[2], transform);
+  doTransform(t_in.corners[3], t_out.corners[3], transform);
+  // TODO(jitrc): add conversion for other fields of BoundingBox, such as heading, variance, size
+}
+
+/******************************/
+/** DetectedObjectKinematics **/
+/******************************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObjectKinematics type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The DetectedObjectKinematics message to transform.
+ * \param t_out The transformed DetectedObjectKinematics message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const DetectedObjectKinematics & t_in, DetectedObjectKinematics & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in; // Copy un-transformable fields
+  // Transform geometric fields
+  doTransform(t_in.centroid_position, t_out.centroid_position, transform);
+  doTransform(t_in.orientation, t_out.orientation, transform);
+  doTransform(t_in.twist, t_out.twist, transform);
+  
+  // Transform position covariance if available
+  if (t_in.has_position_covariance) {
+    // To transform the covariance we will build a new PoseWithCovariance message
+    // since the tf2_geometry_msgs package contains a transformation for that covariance
+    geometry_msgs::msg::PoseWithCovariance cov_pose_in;
+    geometry_msgs::msg::PoseWithCovariance cov_pose_out;
+
+    // The DetectedObjectKinematics covariance is 9 element position. 
+    // This needs to be mapped onto the 36 element PoseWithCovariance covariance.
+    auto xx = t_in.kinematics.position_covariance[0];
+    auto xy = t_in.kinematics.position_covariance[1];
+    auto xz = t_in.kinematics.position_covariance[2];
+    auto yx = t_in.kinematics.position_covariance[3];
+    auto yy = t_in.kinematics.position_covariance[4];
+    auto yz = t_in.kinematics.position_covariance[5];
+    auto zx = t_in.kinematics.position_covariance[6];
+    auto zy = t_in.kinematics.position_covariance[7];
+    auto zz = t_in.kinematics.position_covariance[8];
+
+    // This matrix represents the covariance of the object before transformation
+    std::array<double, 36> input_covariance = { 
+      xx, xy, xz,  0, 0, 0,
+      yx, yy, yz,  0, 0, 0,
+      zx, zy, zz,  0, 0, 0,
+      0,  0,  0,  1,  0, 0, // Since no covariance for the orientation is provided we will assume an identity relationship (1s on the diagonal)
+      0,  0,  0,  0,  1, 0, 
+      0,  0,  0,  0,  0, 1
+    };
+
+    cov_pose_in.covariances = input_covariance;
+
+    doTransform(cov_pose_in, cov_pose_out, transform);
+    
+    // Copy the transformed covariance into the output message
+
+    t_out.kinematics.position_covariance[0] = cov_pose_in.covariances[0];
+    t_out.kinematics.position_covariance[1] = cov_pose_in.covariances[1];
+    t_out.kinematics.position_covariance[2] = cov_pose_in.covariances[2];
+    t_out.kinematics.position_covariance[3] = cov_pose_in.covariances[6];
+    t_out.kinematics.position_covariance[4] = cov_pose_in.covariances[7];
+    t_out.kinematics.position_covariance[5] = cov_pose_in.covariances[8];
+    t_out.kinematics.position_covariance[6] = cov_pose_in.covariances[12];
+    t_out.kinematics.position_covariance[7] = cov_pose_in.covariances[13];
+    t_out.kinematics.position_covariance[8] = cov_pose_in.covariances[14];
+  }
+}
+
+/***********/
+/** Shape **/
+/***********/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs Shape type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The Shape message to transform.
+ * \param t_out The transformed Shape message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const Shapes & t_in, Shape & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in; // Copy un-transformable fields
+
+  // Transform polygon
+  doTransform(t_in.polygon, t_out.polygon, transform);
+
+  // Correct height field based on transformed polygon. 
+  // Z is always gravity-aligned according to the message spec
+  double min_z = std::numeric_limits<double>::max();
+  double max_z = std::numeric_limits<double>::lowest();
+  
+  for (auto p : t_out.polygon.points) {
+    if (p.z < min_z) {
+      min_z = p.z;
+    }
+    if (p.z > max_z) {
+      max_z = p.z;
+    }
+  }
+
+  t_out.height = std::abs(max_z - min_z);
+}
+
 
 }  // namespace tf2
 

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -14,13 +14,6 @@
 /// \file
 /// \brief This file includes common transform functionality for autoware_auto_msgs
 
-/**
- * Copyright (C) 2021 LEIDOS.
- * 
- * Modifications
- * - Add DetectedObjects to the set of supporte types
- */ 
-
 #ifndef AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_HPP_
 #define AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_HPP_
 
@@ -31,27 +24,17 @@
 #include <autoware_auto_msgs/msg/bounding_box.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <autoware_auto_msgs/msg/quaternion32.hpp>
-#include <autoware_auto_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_msgs/msg/detected_object.hpp>
-#include <autoware_auto_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_auto_msgs/msg/shape.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 #include <kdl/frames.hpp>
 #include <common/types.hpp>
 #include <string>
-#include <limits>
 
 
 using autoware::common::types::float32_t;
 using autoware::common::types::float64_t;
 using BoundingBoxArray = autoware_auto_msgs::msg::BoundingBoxArray;
 using BoundingBox = autoware_auto_msgs::msg::BoundingBox;
-using DetectedObject = autoware_auto_msgs::msg::DetectedObject;
-using DetectedObjects = autoware_auto_msgs::msg::DetectedObjects;
-using DetectedObjectKinematics = autoware_auto_msgs::msg::DetectedObjectKinematics;
-using Shape = autoware_auto_msgs::msg::Shape;
-
 
 namespace tf2
 {
@@ -210,140 +193,6 @@ void doTransform(
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
 }
-
-/********************/
-/** DetectedObject **/
-/********************/
-
-/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObject type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The DetectedObject message to transform.
- * \param t_out The transformed DetectedObject message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template<>
-inline
-void doTransform(
-  const DetectedObject & t_in, DetectedObject & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  t_out = t_in;
-  doTransform(t_in.orientation, t_out.orientation, transform);
-  doTransform(t_in.centroid, t_out.centroid, transform);
-  doTransform(t_in.corners[0], t_out.corners[0], transform);
-  doTransform(t_in.corners[1], t_out.corners[1], transform);
-  doTransform(t_in.corners[2], t_out.corners[2], transform);
-  doTransform(t_in.corners[3], t_out.corners[3], transform);
-  // TODO(jitrc): add conversion for other fields of BoundingBox, such as heading, variance, size
-}
-
-/******************************/
-/** DetectedObjectKinematics **/
-/******************************/
-
-/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObjectKinematics type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The DetectedObjectKinematics message to transform.
- * \param t_out The transformed DetectedObjectKinematics message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template<>
-inline
-void doTransform(
-  const DetectedObjectKinematics & t_in, DetectedObjectKinematics & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  t_out = t_in; // Copy un-transformable fields
-  // Transform geometric fields
-  doTransform(t_in.centroid_position, t_out.centroid_position, transform);
-  doTransform(t_in.orientation, t_out.orientation, transform);
-  doTransform(t_in.twist, t_out.twist, transform);
-  
-  // Transform position covariance if available
-  if (t_in.has_position_covariance) {
-    // To transform the covariance we will build a new PoseWithCovariance message
-    // since the tf2_geometry_msgs package contains a transformation for that covariance
-    geometry_msgs::msg::PoseWithCovariance cov_pose_in;
-    geometry_msgs::msg::PoseWithCovariance cov_pose_out;
-
-    // The DetectedObjectKinematics covariance is 9 element position. 
-    // This needs to be mapped onto the 36 element PoseWithCovariance covariance.
-    auto xx = t_in.kinematics.position_covariance[0];
-    auto xy = t_in.kinematics.position_covariance[1];
-    auto xz = t_in.kinematics.position_covariance[2];
-    auto yx = t_in.kinematics.position_covariance[3];
-    auto yy = t_in.kinematics.position_covariance[4];
-    auto yz = t_in.kinematics.position_covariance[5];
-    auto zx = t_in.kinematics.position_covariance[6];
-    auto zy = t_in.kinematics.position_covariance[7];
-    auto zz = t_in.kinematics.position_covariance[8];
-
-    // This matrix represents the covariance of the object before transformation
-    std::array<double, 36> input_covariance = { 
-      xx, xy, xz,  0, 0, 0,
-      yx, yy, yz,  0, 0, 0,
-      zx, zy, zz,  0, 0, 0,
-      0,  0,  0,  1,  0, 0, // Since no covariance for the orientation is provided we will assume an identity relationship (1s on the diagonal)
-      0,  0,  0,  0,  1, 0, 
-      0,  0,  0,  0,  0, 1
-    };
-
-    cov_pose_in.covariances = input_covariance;
-
-    doTransform(cov_pose_in, cov_pose_out, transform);
-    
-    // Copy the transformed covariance into the output message
-
-    t_out.kinematics.position_covariance[0] = cov_pose_in.covariances[0];
-    t_out.kinematics.position_covariance[1] = cov_pose_in.covariances[1];
-    t_out.kinematics.position_covariance[2] = cov_pose_in.covariances[2];
-    t_out.kinematics.position_covariance[3] = cov_pose_in.covariances[6];
-    t_out.kinematics.position_covariance[4] = cov_pose_in.covariances[7];
-    t_out.kinematics.position_covariance[5] = cov_pose_in.covariances[8];
-    t_out.kinematics.position_covariance[6] = cov_pose_in.covariances[12];
-    t_out.kinematics.position_covariance[7] = cov_pose_in.covariances[13];
-    t_out.kinematics.position_covariance[8] = cov_pose_in.covariances[14];
-  }
-}
-
-/***********/
-/** Shape **/
-/***********/
-
-/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs Shape type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The Shape message to transform.
- * \param t_out The transformed Shape message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template<>
-inline
-void doTransform(
-  const Shapes & t_in, Shape & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  t_out = t_in; // Copy un-transformable fields
-
-  // Transform polygon
-  doTransform(t_in.polygon, t_out.polygon, transform);
-
-  // Correct height field based on transformed polygon. 
-  // Z is always gravity-aligned according to the message spec
-  double min_z = std::numeric_limits<double>::max();
-  double max_z = std::numeric_limits<double>::lowest();
-  
-  for (auto p : t_out.polygon.points) {
-    if (p.z < min_z) {
-      min_z = p.z;
-    }
-    if (p.z > max_z) {
-      max_z = p.z;
-    }
-  }
-
-  t_out.height = std::abs(max_z - min_z);
-}
-
 
 }  // namespace tf2
 

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -29,6 +29,7 @@
 #include <kdl/frames.hpp>
 #include <common/types.hpp>
 #include <string>
+#include "tf2_autoware_auto_msgs_extension.hpp"
 
 
 using autoware::common::types::float32_t;

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -29,7 +29,6 @@
 #include <kdl/frames.hpp>
 #include <common/types.hpp>
 #include <string>
-#include "tf2_autoware_auto_msgs_extension.hpp"
 
 
 using autoware::common::types::float32_t;

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs_extension.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs_extension.hpp
@@ -14,11 +14,13 @@
  * the License.
  */
 /// \file
-/// \brief This file includes extensions for the common transform functionality for autoware_auto_msgs
-///        This file is created seperately from tf2_autoware_auto_msgs.hpp to preserve seperation of carma-platform changes from autoware.auto
+/// \brief This file includes extensions for the common transform 
+///        functionality for autoware_auto_msgs
+///        This file is created seperately from tf2_autoware_auto_msgs.hpp to preserve seperation
+///        of carma-platform changes from autoware.auto
 
-#ifndef AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_
-#define AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_
+#ifndef AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSION_HPP_
+#define AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSION_HPP_
 
 #include <tf2/convert.h>
 #include <tf2/time.h>
@@ -34,13 +36,6 @@
 #include <limits>
 #include "tf2_autoware_auto_msgs.hpp"
 #include "tf2_geometry_msgs_extension.hpp"
-
-
-using DetectedObject = autoware_auto_msgs::msg::DetectedObject;
-using DetectedObjects = autoware_auto_msgs::msg::DetectedObjects;
-using DetectedObjectKinematics = autoware_auto_msgs::msg::DetectedObjectKinematics;
-using Shape = autoware_auto_msgs::msg::Shape;
-
 
 namespace tf2
 {
@@ -58,7 +53,7 @@ namespace tf2
 template<>
 inline
 void doTransform(
-  const Shape & t_in, Shape & t_out,
+  const autoware_auto_msgs::msg::Shape & t_in, autoware_auto_msgs::msg::Shape & t_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
   t_out = t_in; // Copy un-transformable fields
@@ -99,7 +94,7 @@ void doTransform(
 template<>
 inline
 void doTransform(
-  const DetectedObjectKinematics & t_in, DetectedObjectKinematics & t_out,
+  const autoware_auto_msgs::msg::DetectedObjectKinematics & t_in, autoware_auto_msgs::msg::DetectedObjectKinematics & t_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
   t_out = t_in; // Copy un-transformable fields
@@ -167,7 +162,7 @@ void doTransform(
 template<>
 inline
 void doTransform(
-  const DetectedObject & t_in, DetectedObject & t_out,
+  const autoware_auto_msgs::msg::DetectedObject & t_in, autoware_auto_msgs::msg::DetectedObject & t_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
   t_out = t_in;
@@ -186,7 +181,7 @@ void doTransform(
  */
 template<>
 inline
-tf2::TimePoint getTimestamp(const DetectedObjects & t)
+tf2::TimePoint getTimestamp(const autoware_auto_msgs::msg::DetectedObjects & t)
 {
   return tf2_ros::fromMsg(t.header.stamp);
 }
@@ -198,7 +193,7 @@ tf2::TimePoint getTimestamp(const DetectedObjects & t)
  */
 template<>
 inline
-std::string getFrameId(const DetectedObjects & t) {return t.header.frame_id;}
+std::string getFrameId(const autoware_auto_msgs::msg::DetectedObjects & t) {return t.header.frame_id;}
 
 /** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObjects type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.
@@ -209,7 +204,7 @@ std::string getFrameId(const DetectedObjects & t) {return t.header.frame_id;}
 template<>
 inline
 void doTransform(
-  const DetectedObjects & t_in, DetectedObjects & t_out,
+  const autoware_auto_msgs::msg::DetectedObjects & t_in, autoware_auto_msgs::msg::DetectedObjects & t_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
   t_out = t_in;
@@ -224,4 +219,4 @@ void doTransform(
 
 }  // namespace tf2
 
-#endif  // AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_
+#endif  // AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSION_HPP_

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs_extension.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs_extension.hpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/// \file
+/// \brief This file includes extensions for the common transform functionality for autoware_auto_msgs
+///        This file is created seperately from tf2_autoware_auto_msgs.hpp to preserve seperation of carma-platform changes from autoware.auto
+
+#ifndef AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_
+#define AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_
+
+#include <tf2/convert.h>
+#include <tf2/time.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <autoware_auto_msgs/msg/detected_objects.hpp>
+#include <autoware_auto_msgs/msg/detected_object.hpp>
+#include <autoware_auto_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_auto_msgs/msg/shape.hpp>
+#include <kdl/frames.hpp>
+#include <common/types.hpp>
+#include <string>
+#include <limits>
+
+
+using DetectedObject = autoware_auto_msgs::msg::DetectedObject;
+using DetectedObjects = autoware_auto_msgs::msg::DetectedObjects;
+using DetectedObjectKinematics = autoware_auto_msgs::msg::DetectedObjectKinematics;
+using Shape = autoware_auto_msgs::msg::Shape;
+
+
+namespace tf2
+{
+
+/********************/
+/** DetectedObjects **/
+/********************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObjects type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The DetectedObjects message to transform.
+ * \param t_out The transformed DetectedObjects message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const DetectedObjects & t_in, DetectedObjects & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in;
+
+  for (size_t i=0; i < t_in.objects.size(); ++i) {
+    doTransform(t_in.objects[i], t_out.objects[i], transform);
+  }
+  
+  t_out.header.frame_id = transform.header.frame_id;
+}
+
+/********************/
+/** DetectedObject **/
+/********************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObject type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The DetectedObject message to transform.
+ * \param t_out The transformed DetectedObject message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const DetectedObject & t_in, DetectedObject & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in;
+  doTransform(t_in.kinematics, t_out.kinematics, transform);
+  doTransform(t_in.shape, t_out.shape, transform);
+}
+
+/******************************/
+/** DetectedObjectKinematics **/
+/******************************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs DetectedObjectKinematics type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The DetectedObjectKinematics message to transform.
+ * \param t_out The transformed DetectedObjectKinematics message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const DetectedObjectKinematics & t_in, DetectedObjectKinematics & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in; // Copy un-transformable fields
+  // Transform geometric fields
+  doTransform(t_in.centroid_position, t_out.centroid_position, transform);
+  doTransform(t_in.orientation, t_out.orientation, transform);
+  doTransform(t_in.twist, t_out.twist, transform);
+  
+  // Transform position covariance if available
+  if (t_in.has_position_covariance) {
+    // To transform the covariance we will build a new PoseWithCovariance message
+    // since the tf2_geometry_msgs package contains a transformation for that covariance
+    geometry_msgs::msg::PoseWithCovariance cov_pose_in;
+    geometry_msgs::msg::PoseWithCovariance cov_pose_out;
+
+    // The DetectedObjectKinematics covariance is 9 element position. 
+    // This needs to be mapped onto the 36 element PoseWithCovariance covariance.
+    auto xx = t_in.kinematics.position_covariance[0];
+    auto xy = t_in.kinematics.position_covariance[1];
+    auto xz = t_in.kinematics.position_covariance[2];
+    auto yx = t_in.kinematics.position_covariance[3];
+    auto yy = t_in.kinematics.position_covariance[4];
+    auto yz = t_in.kinematics.position_covariance[5];
+    auto zx = t_in.kinematics.position_covariance[6];
+    auto zy = t_in.kinematics.position_covariance[7];
+    auto zz = t_in.kinematics.position_covariance[8];
+
+    // This matrix represents the covariance of the object before transformation
+    std::array<double, 36> input_covariance = { 
+      xx, xy, xz,  0, 0, 0,
+      yx, yy, yz,  0, 0, 0,
+      zx, zy, zz,  0, 0, 0,
+      0,  0,  0,  1,  0, 0, // Since no covariance for the orientation is provided we will assume an identity relationship (1s on the diagonal)
+      0,  0,  0,  0,  1, 0, 
+      0,  0,  0,  0,  0, 1
+    };
+
+    cov_pose_in.covariances = input_covariance;
+
+    doTransform(cov_pose_in, cov_pose_out, transform);
+    
+    // Copy the transformed covariance into the output message
+
+    t_out.kinematics.position_covariance[0] = cov_pose_in.covariances[0];
+    t_out.kinematics.position_covariance[1] = cov_pose_in.covariances[1];
+    t_out.kinematics.position_covariance[2] = cov_pose_in.covariances[2];
+    t_out.kinematics.position_covariance[3] = cov_pose_in.covariances[6];
+    t_out.kinematics.position_covariance[4] = cov_pose_in.covariances[7];
+    t_out.kinematics.position_covariance[5] = cov_pose_in.covariances[8];
+    t_out.kinematics.position_covariance[6] = cov_pose_in.covariances[12];
+    t_out.kinematics.position_covariance[7] = cov_pose_in.covariances[13];
+    t_out.kinematics.position_covariance[8] = cov_pose_in.covariances[14];
+  }
+}
+
+/***********/
+/** Shape **/
+/***********/
+
+/** \brief Apply a geometry_msgs TransformStamped to an autoware_auto_msgs Shape type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The Shape message to transform.
+ * \param t_out The transformed Shape message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const Shapes & t_in, Shape & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  t_out = t_in; // Copy un-transformable fields
+
+  // Transform polygon
+  doTransform(t_in.polygon, t_out.polygon, transform);
+
+  // Correct height field based on transformed polygon. 
+  // Z is always gravity-aligned according to the message spec
+  double min_z = std::numeric_limits<double>::max();
+  double max_z = std::numeric_limits<double>::lowest();
+  
+  for (auto p : t_out.polygon.points) {
+    if (p.z < min_z) {
+      min_z = p.z;
+    }
+    if (p.z > max_z) {
+      max_z = p.z;
+    }
+  }
+
+  t_out.height = std::abs(max_z - min_z);
+}
+
+
+}  // namespace tf2
+
+#endif  // AUTOWARE_AUTO_TF2__TF2_AUTOWARE_AUTO_MSGS_EXTENSIONS_HPP_

--- a/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_geometry_msgs_extension.hpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_geometry_msgs_extension.hpp
@@ -1,0 +1,548 @@
+// Copyright 2008 Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage, Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+/** \author Wim Meeussen */
+
+/**
+ * Modifications (C) Leidos 2022
+ * - This file is a partial copy of tf2_geometry_msgs.hpp 
+ *   from https://github.com/ros2/geometry2/blob/7a660094d0da9c463be5fea1df60d836b3349e9b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp
+ *    
+ *   In ROS2 Foxy only the stamped messages have their doTransform function implementations provided.
+ *   In the linked updated file (post foxy) these implementations have been added. 
+ *   Therefore this file contains only the additions. 
+ *   The implementations provided in foxy are still assumed to come from the tf2_geometry_msgs.h file in that package.
+ * 
+ *   NOTE: When carma-platform is updated to target a newer version of ROS2 this file should be removed
+ * 
+ */ 
+
+#ifndef TF2_GEOMETRY_MSGS__TF2_GEOMETRY_MSGS_EXTENSION_HPP_
+#define TF2_GEOMETRY_MSGS__TF2_GEOMETRY_MSGS_EXTENSION_HPP_
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/convert.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2_ros/buffer_interface.h>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/quaternion_stamped.hpp>
+#include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/wrench.hpp>
+#include <geometry_msgs/msg/wrench_stamped.hpp>
+#include <kdl/frames.hpp>
+
+#include <array>
+#include <string>
+
+namespace tf2
+{
+
+
+/*************/
+/** Vector3 **/
+/*************/
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Vector type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The vector to transform, as a Vector3 message.
+ * \param t_out The transformed vector, as a Vector3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Vector3 & t_in,
+  geometry_msgs::msg::Vector3 & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v_out = gmTransformToKDL(transform).M * KDL::Vector(t_in.x, t_in.y, t_in.z);
+  t_out.x = v_out[0];
+  t_out.y = v_out[1];
+  t_out.z = v_out[2];
+}
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::msg::Vector3 toMsg(const tf2::Vector3 & in)
+{
+  geometry_msgs::msg::Vector3 out;
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Vector3 & in, tf2::Vector3 & out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
+
+
+/***********/
+/** Point **/
+/***********/
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Point type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The point to transform, as a Point3 message.
+ * \param t_out The transformed point, as a Point3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Point & t_in,
+  geometry_msgs::msg::Point & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.x, t_in.y, t_in.z);
+  t_out.x = v_out[0];
+  t_out.y = v_out[1];
+  t_out.z = v_out[2];
+}
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::msg::Point & toMsg(const tf2::Vector3 & in, geometry_msgs::msg::Point & out)
+{
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Point & in, tf2::Vector3 & out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
+
+
+/************************/
+/** PoseWithCovariance **/
+/************************/
+
+// Forward declaration
+void fromMsg(const geometry_msgs::msg::Transform & in, tf2::Transform & out);
+
+/** 
+ * NOTE: This function was recently backported to foxy in this PR https://github.com/ros2/geometry2/commit/47a703ed8f281cde732cb800c376d6620b8a9ff7
+ *       However, the sync has not yet occurred. Therefore it will be needed here until the update happens.
+ *       Once the update occurs it should be removed
+ * 
+ * \brief Transform the covariance matrix of a PoseWithCovariance message to a new frame.
+ * \param cov_in The covariance matrix to transform.
+ * \param transform The transform to apply, as a tf2::Transform structure.
+ * \return The transformed covariance matrix.
+ */
+inline
+geometry_msgs::msg::PoseWithCovariance::_covariance_type transformCovariance(
+  const geometry_msgs::msg::PoseWithCovariance::_covariance_type & cov_in,
+  const tf2::Transform & transform)
+{
+    /**
+     * To transform a covariance matrix:
+     *
+     * \verbatim[R 0] COVARIANCE [R' 0 ]
+      [0 R]            [0  R']\endverbatim
+     *
+     * Where:
+     *         R is the rotation matrix (3x3).
+     *         R' is the transpose of the rotation matrix.
+     *         COVARIANCE is the 6x6 covariance matrix to be transformed.
+     *
+     * Reference:
+     *         A. L. Garcia, “Linear Transformations of Random Vectors,” in Probability,
+     *         Statistics, and Random Processes For Electrical Engineering, 3rd ed.,
+     *         Pearson Prentice Hall, 2008, pp. 320–322.
+     */
+
+    // get rotation matrix (and transpose)
+    const tf2::Matrix3x3 R = transform.getBasis();
+    const tf2::Matrix3x3 R_transpose = R.transpose();
+
+    // convert covariance matrix into four 3x3 blocks
+    const tf2::Matrix3x3 cov_11(cov_in[0], cov_in[1], cov_in[2],
+                                cov_in[6], cov_in[7], cov_in[8],
+                                cov_in[12], cov_in[13], cov_in[14]);
+    const tf2::Matrix3x3 cov_12(cov_in[3], cov_in[4], cov_in[5],
+                                cov_in[9], cov_in[10], cov_in[11],
+                                cov_in[15], cov_in[16], cov_in[17]);
+    const tf2::Matrix3x3 cov_21(cov_in[18], cov_in[19], cov_in[20],
+                                cov_in[24], cov_in[25], cov_in[26],
+                                cov_in[30], cov_in[31], cov_in[32]);
+    const tf2::Matrix3x3 cov_22(cov_in[21], cov_in[22], cov_in[23],
+                                cov_in[27], cov_in[28], cov_in[29],
+                                cov_in[33], cov_in[34], cov_in[35]);
+
+    // perform blockwise matrix multiplication
+    const tf2::Matrix3x3 result_11 = R * cov_11 * R_transpose;
+    const tf2::Matrix3x3 result_12 = R * cov_12 * R_transpose;
+    const tf2::Matrix3x3 result_21 = R * cov_21 * R_transpose;
+    const tf2::Matrix3x3 result_22 = R * cov_22 * R_transpose;
+
+    // form the output
+    geometry_msgs::msg::PoseWithCovariance::_covariance_type cov_out;
+    cov_out[0] = result_11[0][0];
+    cov_out[1] = result_11[0][1];
+    cov_out[2] = result_11[0][2];
+    cov_out[6] = result_11[1][0];
+    cov_out[7] = result_11[1][1];
+    cov_out[8] = result_11[1][2];
+    cov_out[12] = result_11[2][0];
+    cov_out[13] = result_11[2][1];
+    cov_out[14] = result_11[2][2];
+
+    cov_out[3] = result_12[0][0];
+    cov_out[4] = result_12[0][1];
+    cov_out[5] = result_12[0][2];
+    cov_out[9] = result_12[1][0];
+    cov_out[10] = result_12[1][1];
+    cov_out[11] = result_12[1][2];
+    cov_out[15] = result_12[2][0];
+    cov_out[16] = result_12[2][1];
+    cov_out[17] = result_12[2][2];
+
+    cov_out[18] = result_21[0][0];
+    cov_out[19] = result_21[0][1];
+    cov_out[20] = result_21[0][2];
+    cov_out[24] = result_21[1][0];
+    cov_out[25] = result_21[1][1];
+    cov_out[26] = result_21[1][2];
+    cov_out[30] = result_21[2][0];
+    cov_out[31] = result_21[2][1];
+    cov_out[32] = result_21[2][2];
+
+    cov_out[21] = result_22[0][0];
+    cov_out[22] = result_22[0][1];
+    cov_out[23] = result_22[0][2];
+    cov_out[27] = result_22[1][0];
+    cov_out[28] = result_22[1][1];
+    cov_out[29] = result_22[1][2];
+    cov_out[33] = result_22[2][0];
+    cov_out[34] = result_22[2][1];
+    cov_out[35] = result_22[2][2];
+
+    return cov_out;
+}
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The pose to transform, as a Pose3 message with covariance.
+ * \param t_out The transformed pose, as a Pose3 message with covariance.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::PoseWithCovariance & t_in,
+  geometry_msgs::msg::PoseWithCovariance & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v(t_in.pose.position.x, t_in.pose.position.y, t_in.pose.position.z);
+  KDL::Rotation r = KDL::Rotation::Quaternion(
+    t_in.pose.orientation.x, t_in.pose.orientation.y,
+    t_in.pose.orientation.z, t_in.pose.orientation.w);
+
+  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
+  t_out.pose.position.x = v_out.p[0];
+  t_out.pose.position.y = v_out.p[1];
+  t_out.pose.position.z = v_out.p[2];
+  v_out.M.GetQuaternion(
+    t_out.pose.orientation.x, t_out.pose.orientation.y,
+    t_out.pose.orientation.z, t_out.pose.orientation.w);
+
+  tf2::Transform tf_transform;
+  fromMsg(transform.transform, tf_transform);
+  t_out.covariance = transformCovariance(t_in.covariance, tf_transform);
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A PoseWithCovariance message.
+ * \return The input argument.
+ */
+inline
+geometry_msgs::msg::PoseWithCovariance toMsg(const geometry_msgs::msg::PoseWithCovariance & in)
+{
+  return in;
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A PoseWithCovariance message.
+ * \param out The input argument.
+ */
+inline
+void fromMsg(
+  const geometry_msgs::msg::PoseWithCovariance & msg,
+  geometry_msgs::msg::PoseWithCovariance & out)
+{
+  out = msg;
+}
+
+/****************/
+/** Quaternion **/
+/****************/
+
+// Forward declaration
+geometry_msgs::msg::Quaternion toMsg(const tf2::Quaternion & in);
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Quaternion type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The quaternion to transform, as a Quaternion3 message.
+ * \param t_out The transformed quaternion, as a Quaternion3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Quaternion & t_in,
+  geometry_msgs::msg::Quaternion & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  tf2::Quaternion q_out = tf2::Quaternion(
+    transform.transform.rotation.x, transform.transform.rotation.y,
+    transform.transform.rotation.z, transform.transform.rotation.w) *
+    tf2::Quaternion(t_in.x, t_in.y, t_in.z, t_in.w);
+  t_out = toMsg(q_out);
+}
+
+
+
+/***************/
+/** Transform **/
+/***************/
+
+/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
+ * \param in A tf2 Transform object.
+ * \param out The Transform converted to a geometry_msgs message type.
+ */
+inline
+/** This section is about converting */
+void toMsg(const tf2::Transform & in, geometry_msgs::msg::Transform & out)
+{
+  out = toMsg(in);
+}
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Transform type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The frame to transform, as a Transform3 message.
+ * \param t_out The frame transform, as a Transform3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Transform & t_in,
+  geometry_msgs::msg::Transform & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v(t_in.translation.x, t_in.translation.y,
+    t_in.translation.z);
+  KDL::Rotation r = KDL::Rotation::Quaternion(
+    t_in.rotation.x, t_in.rotation.y,
+    t_in.rotation.z, t_in.rotation.w);
+
+  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
+  t_out.translation.x = v_out.p[0];
+  t_out.translation.y = v_out.p[1];
+  t_out.translation.z = v_out.p[2];
+  v_out.M.GetQuaternion(
+    t_out.rotation.x, t_out.rotation.y,
+    t_out.rotation.z, t_out.rotation.w);
+}
+
+/**********/
+/** Pose **/
+/**********/
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The pose to transform, as a Pose3 message.
+ * \param t_out The transformed pose, as a Pose3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Pose & t_in,
+  geometry_msgs::msg::Pose & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v(t_in.position.x, t_in.position.y, t_in.position.z);
+  KDL::Rotation r = KDL::Rotation::Quaternion(
+    t_in.orientation.x, t_in.orientation.y,
+    t_in.orientation.z, t_in.orientation.w);
+
+  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
+  t_out.position.x = v_out.p[0];
+  t_out.position.y = v_out.p[1];
+  t_out.position.z = v_out.p[2];
+  v_out.M.GetQuaternion(
+    t_out.orientation.x, t_out.orientation.y,
+    t_out.orientation.z, t_out.orientation.w);
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A Pose message.
+ * \return The input argument.
+ */
+inline
+geometry_msgs::msg::Pose toMsg(const geometry_msgs::msg::Pose & in)
+{
+  return in;
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A Pose message.
+ * \param out The input argument.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::Pose & msg, geometry_msgs::msg::Pose & out)
+{
+  out = msg;
+}
+
+/**********************/
+/*** WrenchStamped ****/
+/**********************/
+
+/** \brief Extract a timestamp from the header of a Wrench message.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * \param t WrenchStamped message to extract the timestamp from.
+ * \return The timestamp of the message.
+ */
+template<>
+inline
+tf2::TimePoint getTimestamp(const geometry_msgs::msg::WrenchStamped & t)
+{
+  return tf2_ros::fromMsg(t.header.stamp);
+}
+
+/** \brief Extract a frame ID from the header of a Wrench message.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * \param t WrenchStamped message to extract the frame ID from.
+ * \return A string containing the frame ID of the message.
+ */
+template<>
+inline
+std::string getFrameId(const geometry_msgs::msg::WrenchStamped & t) {return t.header.frame_id;}
+
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Wrench type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The wrench to transform, as a Wrench message.
+ * \param t_out The transformed wrench, as a Wrench message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Wrench & t_in, geometry_msgs::msg::Wrench & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  doTransform(t_in.force, t_out.force, transform);
+  doTransform(t_in.torque, t_out.torque, transform);
+}
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs WrenchStamped type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The wrench to transform, as a timestamped Wrench message.
+ * \param t_out The transformed wrench, as a timestamped Wrench message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::WrenchStamped & t_in,
+  geometry_msgs::msg::WrenchStamped & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  doTransform(t_in.wrench, t_out.wrench, transform);
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
+
+/** \brief Trivial "conversion" function for Wrench message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A WrenchStamped message.
+ * \return The input argument.
+ */
+inline
+geometry_msgs::msg::WrenchStamped toMsg(const geometry_msgs::msg::WrenchStamped & in)
+{
+  return in;
+}
+
+/** \brief Trivial "conversion" function for Wrench message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A WrenchStamped message.
+ * \param out The input argument.
+ */
+inline
+void fromMsg(const geometry_msgs::msg::WrenchStamped & msg, geometry_msgs::msg::WrenchStamped & out)
+{
+  out = msg;
+}
+
+}  // namespace tf2
+
+#endif  // TF2_GEOMETRY_MSGS__TF2_GEOMETRY_MSGS_EXTENSION_HPP_

--- a/AutowareAuto/src/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs_extension.cpp
+++ b/AutowareAuto/src/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs_extension.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#include <gtest/gtest.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <autoware_auto_tf2/tf2_autoware_auto_msgs_extension.hpp>
+#include <rclcpp/clock.hpp>
+#include <memory>
+
+// Forward declare filled_transform
+geometry_msgs::msg::TransformStamped filled_transfom();
+
+constexpr double eps = 1e-3;
+
+TEST(Tf2AutowareAuto, DoTransformShape)
+{
+  const auto trans = filled_transfom();
+  autoware_auto_msgs::msg::Shape shape;
+  geometry_msgs::msg::Polygon poly;
+  geometry_msgs::msg::Point32 p1;
+  p1.x = 1;
+  p1.y = 2;
+  p1.z = 3;
+  poly.points.push_back(p1);
+
+  shape.polygon = poly;
+  shape.height = 0;
+
+  // doTransform
+  autoware_auto_msgs::msg::Shape shape_out;
+  tf2::doTransform(shape, shape_out, trans);
+
+  ASSERT_EQ(shape_out.polygon.points.size(), 1u);
+  EXPECT_NEAR(shape_out.polygon.points[0].x, 11, eps);
+  EXPECT_NEAR(shape_out.polygon.points[0].y, 18, eps);
+  EXPECT_NEAR(shape_out.polygon.points[0].z, 27, eps);
+  EXPECT_NEAR(shape_out.height, 0, eps);
+}
+
+TEST(Tf2AutowareAuto, DoTransformDetectedObjectKinematics)
+{
+  const auto trans = filled_transfom();
+  autoware_auto_msgs::msg::DetectedObjectKinematics  dok;
+  dok.orientation.w = 0;
+  dok.orientation.x = 0;
+  dok.orientation.y = 0;
+  dok.orientation.z = 1;
+  dok.centroid_position.x = 1;
+  dok.centroid_position.y = 2;
+  dok.centroid_position.z = 3;
+  dok.twist.twist.linear.x = 1;
+  dok.twist.twist.linear.y = 2;
+  dok.twist.twist.linear.z = 3;
+  dok.twist.twist.angular.x = 4;
+  dok.twist.twist.angular.y = 5;
+  dok.twist.twist.angular.z = 6;
+
+
+  // doTransform
+  autoware_auto_msgs::msg::DetectedObjectKinematics dok_out;
+  tf2::doTransform(dok, dok_out, trans);
+
+  EXPECT_NEAR(dok_out.orientation.w, 0.0, eps);
+  EXPECT_NEAR(dok_out.orientation.x, 0.0, eps);
+  EXPECT_NEAR(dok_out.orientation.y, -1.0, eps);
+  EXPECT_NEAR(dok_out.orientation.z, 0.0, eps);
+  EXPECT_NEAR(dok_out.centroid_position.x, 11, eps);
+  EXPECT_NEAR(dok_out.centroid_position.y, 18, eps);
+  EXPECT_NEAR(dok_out.centroid_position.z, 27, eps);
+
+  // Verify twist is unchanged
+  EXPECT_NEAR(dok_out.twist.twist.linear.x, 1, eps);
+  EXPECT_NEAR(dok_out.twist.twist.linear.y, 2, eps);
+  EXPECT_NEAR(dok_out.twist.twist.linear.z, 3, eps);
+  EXPECT_NEAR(dok_out.twist.twist.angular.x, 4, eps);
+  EXPECT_NEAR(dok_out.twist.twist.angular.y, 5, eps);
+  EXPECT_NEAR(dok_out.twist.twist.angular.z, 6, eps);
+
+
+  // Testing unused fields are unmodified
+  EXPECT_EQ(dok_out.has_position_covariance, dok.has_position_covariance);
+  EXPECT_EQ(dok_out.orientation_availability, dok.orientation_availability);
+  EXPECT_EQ(dok_out.has_twist, dok.has_twist);
+  EXPECT_EQ(dok_out.has_twist_covariance, dok.has_twist_covariance);
+
+}
+
+TEST(Tf2AutowareAuto, TransformDetectedObject)
+{
+  const auto trans = filled_transfom();
+  autoware_auto_msgs::msg::DetectedObject obj;
+  geometry_msgs::msg::Polygon poly;
+  geometry_msgs::msg::Point32 p1;
+  p1.x = 1;
+  p1.y = 2;
+  p1.z = 3;
+  poly.points.push_back(p1);
+
+  obj.shape.polygon = poly;
+  obj.shape.height = 0;
+
+  obj.kinematics.orientation.w = 0;
+  obj.kinematics.orientation.x = 0;
+  obj.kinematics.orientation.y = 0;
+  obj.kinematics.orientation.z = 1;
+  obj.kinematics.centroid_position.x = 1;
+  obj.kinematics.centroid_position.y = 2;
+  obj.kinematics.centroid_position.z = 3;
+  obj.kinematics.twist.twist.linear.x = 1;
+  obj.kinematics.twist.twist.linear.y = 2;
+  obj.kinematics.twist.twist.linear.z = 3;
+  obj.kinematics.twist.twist.angular.x = 4;
+  obj.kinematics.twist.twist.angular.y = 5;
+  obj.kinematics.twist.twist.angular.z = 6;
+
+  // doTransform
+  autoware_auto_msgs::msg::DetectedObject obj_out;
+  tf2::doTransform(obj, obj_out, trans);
+
+  ASSERT_EQ(obj_out.shape.polygon.points.size(), 1u);
+  EXPECT_NEAR(obj_out.shape.polygon.points[0].x, 11, eps);
+  EXPECT_NEAR(obj_out.shape.polygon.points[0].y, 18, eps);
+  EXPECT_NEAR(obj_out.shape.polygon.points[0].z, 27, eps);
+  EXPECT_NEAR(obj_out.shape.height, 0, eps);
+
+  EXPECT_NEAR(obj_out.kinematics.orientation.w, 0.0, eps);
+  EXPECT_NEAR(obj_out.kinematics.orientation.x, 0.0, eps);
+  EXPECT_NEAR(obj_out.kinematics.orientation.y, -1.0, eps);
+  EXPECT_NEAR(obj_out.kinematics.orientation.z, 0.0, eps);
+  EXPECT_NEAR(obj_out.kinematics.centroid_position.x, 11, eps);
+  EXPECT_NEAR(obj_out.kinematics.centroid_position.y, 18, eps);
+  EXPECT_NEAR(obj_out.kinematics.centroid_position.z, 27, eps);
+
+  // Verify twist is unchanged
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.linear.x, 1, eps);
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.linear.y, 2, eps);
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.linear.z, 3, eps);
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.angular.x, 4, eps);
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.angular.y, 5, eps);
+  EXPECT_NEAR(obj_out.kinematics.twist.twist.angular.z, 6, eps);
+
+
+  // Testing unused fields are unmodified
+  EXPECT_EQ(obj_out.kinematics.has_position_covariance, obj.kinematics.has_position_covariance);
+  EXPECT_EQ(obj_out.kinematics.orientation_availability, obj.kinematics.orientation_availability);
+  EXPECT_EQ(obj_out.kinematics.has_twist, obj.kinematics.has_twist);
+  EXPECT_EQ(obj_out.kinematics.has_twist_covariance, obj.kinematics.has_twist_covariance);
+
+  // Object fields
+  EXPECT_EQ(obj_out.existence_probability, obj.existence_probability);
+
+}
+
+TEST(Tf2AutowareAuto, TransformDetectedObjects)
+{
+  const auto trans = filled_transfom();
+  autoware_auto_msgs::msg::DetectedObjects objs;
+  autoware_auto_msgs::msg::DetectedObject obj;
+  geometry_msgs::msg::Polygon poly;
+  geometry_msgs::msg::Point32 p1;
+  p1.x = 1;
+  p1.y = 2;
+  p1.z = 3;
+  poly.points.push_back(p1);
+
+  obj.shape.polygon = poly;
+  obj.shape.height = 0;
+
+  obj.kinematics.orientation.w = 0;
+  obj.kinematics.orientation.x = 0;
+  obj.kinematics.orientation.y = 0;
+  obj.kinematics.orientation.z = 1;
+  obj.kinematics.centroid_position.x = 1;
+  obj.kinematics.centroid_position.y = 2;
+  obj.kinematics.centroid_position.z = 3;
+  obj.kinematics.twist.twist.linear.x = 1;
+  obj.kinematics.twist.twist.linear.y = 2;
+  obj.kinematics.twist.twist.linear.z = 3;
+  obj.kinematics.twist.twist.angular.x = 4;
+  obj.kinematics.twist.twist.angular.y = 5;
+  obj.kinematics.twist.twist.angular.z = 6;
+
+  objs.objects.push_back(obj);
+  objs.header.frame_id = "B";
+
+  // doTransform
+  autoware_auto_msgs::msg::DetectedObjects objs_out;
+  tf2::doTransform(objs, objs_out, trans);
+
+  // Partial field check here, relying on other tests for full verification
+  ASSERT_TRUE(objs_out.header.frame_id == trans.header.frame_id);
+  ASSERT_EQ(objs_out.objects.size(), 1u);
+  ASSERT_EQ(objs_out.objects[0].shape.polygon.points.size(), 1u);
+  EXPECT_NEAR(objs_out.objects[0].shape.polygon.points[0].x, 11, eps);
+  EXPECT_NEAR(objs_out.objects[0].shape.polygon.points[0].y, 18, eps);
+  EXPECT_NEAR(objs_out.objects[0].shape.polygon.points[0].z, 27, eps);
+  EXPECT_NEAR(objs_out.objects[0].shape.height, 0, eps);
+}

--- a/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/tracking_nodes.param.yaml
+++ b/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/tracking_nodes.param.yaml
@@ -24,6 +24,9 @@ object_association.max_area_ratio: 2.5
   # When true, the shortest edge of the detection will be used as the max distance threshold if it is greater than the configured threshold
 object_association.consider_edge_for_big_detection: True
 
+# The frame in which to do tracking.
+track_frame_id: 'map'
+
 # Parameter to allow the tracker to use vision detections for improving tracking.
 use_vision: False
 # Number of vision topics to subscribe to.

--- a/AutowareAuto/src/perception/tracking_nodes/src/multi_object_tracker_node.cpp
+++ b/AutowareAuto/src/perception/tracking_nodes/src/multi_object_tracker_node.cpp
@@ -14,6 +14,11 @@
 //
 // Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
+/**
+ * Modification Copyright (C) Leidos 2022
+ *  - Removed && result.maybe_roi_stamps check from detected objects callback as it was never being set
+ */ 
+
 #include <tracking_nodes/multi_object_tracker_node.hpp>
 
 #include <rclcpp_components/register_node_macro.hpp>
@@ -247,7 +252,7 @@ void MultiObjectTrackerNode::detected_objects_callback(const DetectedObjects::Co
   }
   const auto result = m_tracker.update(
     *objs, *get_closest_match(matched_msgs, objs->header.stamp));
-  if (result.status == TrackerUpdateStatus::Ok && result.maybe_roi_stamps) {
+  if (result.status == TrackerUpdateStatus::Ok) {
     m_track_publisher->publish(result.tracks);
     m_leftover_publisher->publish(result.unassigned_clusters);
     maybe_visualize(*(result.maybe_roi_stamps), *objs);


### PR DESCRIPTION
Autoware.Auto contains an autoware_auto_tf messages package which contains the doTransform specializations/overloads for some of the internal messages used in that system. However, it does not contain one for DetectedObjects. This PR adds a new tf2_autoware_auto_msgs_extension.hpp file to that package that includes this implementation. It is added as a separate file to minimize merge conflicts with any future updates to autoware.auto. To create these doTransform functions some additional overloads were needed from tf2_geometry_msgs which are not included in the current ROS2 Foxy release. They are however present in ROS2 Galactic. Therefore, a tf2_geometry_msgs_extension.hpp file was created which provides these implementations (copy and pasted from the ROS2 source). If these implementations are ever backported or the ROS2 version updated then these can be removed. 

Along with the above changes, 2 small changes were also made to the Autoware.Auto tracking_nodes package, the track_frame_id parameter was added to the parameter file as it was missing. And the maybe_roi_stamps flag for tracking results was removed from the check call as it is never set in the source code and is not relevant for lidar only tracking. 

Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1557

These changes were integration tested on the silver lexus