### PR TITLE
[#1360] Fix point cloud wrapper misuse in ray_ground_classifier_nodes

### DIFF
--- a/AutowareAuto/src/perception/filters/ray_ground_classifier_nodes/include/ray_ground_classifier_nodes/ray_ground_classifier_cloud_node.hpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier_nodes/include/ray_ground_classifier_nodes/ray_ground_classifier_cloud_node.hpp
@@ -77,8 +77,6 @@ private:
   const std::shared_ptr<rclcpp::Publisher<PointCloud2>> m_nonground_pub_ptr;
   /// \brief Read samples from the subscription
   void callback(const PointCloud2::SharedPtr msg);
-  uint32_t m_ground_pc_idx;
-  uint32_t m_nonground_pc_idx;
 };  // class RayGroundFilterDriverNode
 }  // namespace ray_ground_classifier_nodes
 }  // namespace filters

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier_nodes/test/src/test_ray_ground_classifier_nodes.cpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier_nodes/test/src/test_ray_ground_classifier_nodes.cpp
@@ -66,6 +66,7 @@ public:
     for (std::size_t i = 0; i < m_ground_points.size(); i++) {
       ret = (m_ground_points[i].data.size() == expected_ground_pcl_size) && ret;
       std::cout << "ground pc actual size = " << m_ground_points[i].data.size() << std::endl;
+      std::cout << "ground pc expected size = " << expected_ground_pcl_size << std::endl;
     }
     return ret;
   }
@@ -87,6 +88,7 @@ public:
     for (std::size_t i = 0; i < m_nonground_points.size(); i++) {
       ret = (m_nonground_points[i].data.size() == expected_nongnd_pcl_size) && ret;
       std::cout << "nonground pc actual size = " << m_nonground_points[i].data.size() << std::endl;
+      std::cout << "nonground pc expected size = " << expected_nongnd_pcl_size << std::endl;
     }
     return ret;
   }


### PR DESCRIPTION
This PR performs a git cherry-pick for autoware.auto commit https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/commit/3930b2e0c6410839b3c47edf556b834ec3f0fc56

This cherry-picked commit contains fixes for https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/issues/1360 which seems to be the probable cause of issues discovered during integration testing where the ray_ground_filter was not publishing actual data. 

I would have liked to merge everything from the autoware_auto master but they separated their message specs into multiple packages which will take time to integrate with carma. So for now I am using only this fix. 