### PR TITLE
Fix/correct orientation on detected objects

### DIFF
--- a/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/ray_ground_classifier.param.yaml
+++ b/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/ray_ground_classifier.param.yaml
@@ -2,8 +2,8 @@ timeout_ms:       10
 cloud_timeout_ms: 110
 pcl_size:         55000
 frame_id:        "base_link"
-is_structured:    true
-classifier.sensor_height_m:                     0.368
+is_structured:    false
+classifier.sensor_height_m:                     0.0
 classifier.max_local_slope_deg:                 20.0
 classifier.max_global_slope_deg:                7.0
 classifier.nonground_retro_thresh_deg:          70.0

--- a/AutowareAuto/src/perception/tracking/include/tracking/tracked_object.hpp
+++ b/AutowareAuto/src/perception/tracking/include/tracking/tracked_object.hpp
@@ -123,6 +123,8 @@ private:
   common::types::float64_t m_default_variance = -1.0;
   /// Track class classifier.
   ClassificationTracker m_classifier;
+  /// Unfiltered orientation used to track objects
+  geometry_msgs::msg::Quaternion unfiltered_orientation;
 };
 
 

--- a/AutowareAuto/src/perception/tracking/src/multi_object_tracker.cpp
+++ b/AutowareAuto/src/perception/tracking/src/multi_object_tracker.cpp
@@ -233,6 +233,21 @@ MultiObjectTracker::DetectedObjectsMsg MultiObjectTracker::transform(
     tf2::fromMsg(detection.kinematics.centroid_position, centroid_detection);
     const Eigen::Vector3d centroid_tracking = tf__tracking__detection * centroid_detection;
     detection.kinematics.centroid_position = tf2::toMsg(centroid_tracking);
+
+    // TODO taken from autoware.auto commit 670f0fae65c34280418bb6adf51fd7cca21b0baf 
+    // This if block can be removed when the whole autoware.auto fork is updated to the latest version
+    if (detection.kinematics.orientation_availability != autoware_auto_msgs::msg::DetectedObjectKinematics::UNAVAILABLE) {
+      geometry_msgs::msg::QuaternionStamped q_out;
+      // Use quaternion stamped because there is no doTransform for quaternion even though
+      // stamp of QuaternionStamped is not being used for anything
+      tf2::doTransform(
+        geometry_msgs::msg::QuaternionStamped{}.set__quaternion(
+          detection.kinematics.orientation),
+        q_out,
+        tf_msg__tracking__detection);
+      detection.kinematics.orientation = q_out.quaternion;
+    }
+
     if (detection.kinematics.has_position_covariance) {
       // Doing this properly is difficult. We'll ignore the rotational part. This is a practical
       // solution since only the yaw covariance is relevant, and the yaw covariance is

--- a/AutowareAuto/src/perception/tracking/src/multi_object_tracker.cpp
+++ b/AutowareAuto/src/perception/tracking/src/multi_object_tracker.cpp
@@ -127,6 +127,7 @@ DetectedObjectsUpdateResult MultiObjectTracker::update(
       continue;
     }
     const auto & detection = detection_in_tracker_frame.objects[detection_idx];
+    m_tracks.objects[track_idx].unfiltered_orientation = detection.kinematics.orientation;
     m_tracks.objects[track_idx].update(detection);
   }
   for (const size_t track_idx : association.unassigned_track_indices) {

--- a/AutowareAuto/src/perception/tracking/src/track_creator.cpp
+++ b/AutowareAuto/src/perception/tracking/src/track_creator.cpp
@@ -63,8 +63,9 @@ TrackCreationResult LidarOnlyPolicy::create()
 {
   TrackCreationResult retval;
   for (const auto & cluster : m_lidar_clusters.objects) {
-    retval.tracks.emplace_back(
-      TrackedObject(cluster, m_default_variance, m_noise_variance));
+    TrackedObject track(cluster, m_default_variance, m_noise_variance);
+    track.unfiltered_orientation = cluster.kinematics.orientation;
+    retval.tracks.emplace_back(track);
   }
   return retval;
 }

--- a/AutowareAuto/src/perception/tracking/src/tracked_object.cpp
+++ b/AutowareAuto/src/perception/tracking/src/tracked_object.cpp
@@ -212,6 +212,9 @@ const TrackedObject::TrackedObjectMsg & TrackedObject::msg()
     m_ekf.state().index_of<Y_VELOCITY>());
   m_msg.classification = m_classifier.object_classification_vector();
   // TODO(nikolai.morin): Set is_stationary etc.
+
+  m_msg.kinematics.orientation = track.
+
   return m_msg;
 }
 


### PR DESCRIPTION
This PR supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1557 by creating a passthrough for the bounding box orientation reported by the Euclidean cluster nodes inside the tracking nodes. Since the orientation is not part of the internal kalman filter it was previously dropped. This PR serves as a workaround to pass it through unfiltered. 