### PR TITLE
Fix/buffer

### DIFF
--- a/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/ray_ground_classifier.param.yaml
+++ b/AutowareAuto/src/launch/autoware_auto_launch/param/component_style/ray_ground_classifier.param.yaml
@@ -16,4 +16,4 @@ classifier.max_height_m:                        1.5
 aggregator.min_ray_angle_rad: -3.14159
 aggregator.max_ray_angle_rad:  3.14159
 aggregator.ray_width_rad:      0.01
-aggregator.max_ray_points:     512
+aggregator.max_ray_points:     512 # Cannot be increased as 512 is a hardcoded max. Only decreasing is possible

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/include/ray_ground_classifier/ray_aggregator.hpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/include/ray_ground_classifier/ray_aggregator.hpp
@@ -20,6 +20,7 @@
 #ifndef RAY_GROUND_CLASSIFIER__RAY_AGGREGATOR_HPP_
 #define RAY_GROUND_CLASSIFIER__RAY_AGGREGATOR_HPP_
 
+// Mikes change
 
 #include <algorithm>
 #include <cmath>

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/include/ray_ground_classifier/ray_aggregator.hpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/include/ray_ground_classifier/ray_aggregator.hpp
@@ -20,7 +20,6 @@
 #ifndef RAY_GROUND_CLASSIFIER__RAY_AGGREGATOR_HPP_
 #define RAY_GROUND_CLASSIFIER__RAY_AGGREGATOR_HPP_
 
-// Mikes change
 
 #include <algorithm>
 #include <cmath>

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
@@ -150,7 +150,7 @@ bool8_t RayAggregator::insert(const PointXYZIFR & pt)
         print_overflow = false;
       }
       return false;
-      //throw std::runtime_error("RayAggregator: Ray capacity overrun! Use smaller bins");
+      //throw std::runtime_error("RayAggregator: Ray capacity overrun! Use smaller bins"); // NOTE see https://github.com/usdot-fhwa-stol/carma-platform/issues/1776 to understand why this is disabled
     }
     // insert point to ray, do some presorting
     ray.push_back(pt);

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
@@ -146,7 +146,7 @@ bool8_t RayAggregator::insert(const PointXYZIFR & pt)
     }
     if (ray.size() >= ray.capacity()) {
       if (print_overflow) {
-        std::cerr << "RayAggregator: Ray capacity overrun! Use smaller bins" << std::endl;
+        std::cerr << "Hello RayAggregator: Ray capacity overrun! Use smaller bins" << std::endl;
         print_overflow = false;
       }
       return false;

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
@@ -146,7 +146,7 @@ bool8_t RayAggregator::insert(const PointXYZIFR & pt)
     }
     if (ray.size() >= ray.capacity()) {
       if (print_overflow) {
-        std::cerr << "Hello RayAggregator: Ray capacity overrun! Use smaller bins" << std::endl;
+        std::cerr << "RayAggregator: Ray capacity overrun! Use smaller bins" << std::endl;
         print_overflow = false;
       }
       return false;

--- a/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
+++ b/AutowareAuto/src/perception/filters/ray_ground_classifier/src/ray_aggregator.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
+#include <iostream>
 
 #include "common/types.hpp"
 #include "lidar_utils/lidar_utils.hpp"
@@ -131,6 +132,7 @@ void RayAggregator::end_of_scan()
 ////////////////////////////////////////////////////////////////////////////////
 bool8_t RayAggregator::insert(const PointXYZIFR & pt)
 {
+  static bool print_overflow = true;
   if (static_cast<uint16_t>(PointXYZIF::END_OF_SCAN_ID) == pt.get_point_pointer()->id) {
     return false;
   } else {
@@ -138,11 +140,17 @@ bool8_t RayAggregator::insert(const PointXYZIFR & pt)
 
     Ray & ray = m_rays[idx];
     if (RayState::RESET == m_ray_state[idx]) {
+      print_overflow = true;
       ray.clear();  // capacity unchanged
       m_ray_state[idx] = RayState::NOT_READY;
     }
     if (ray.size() >= ray.capacity()) {
-      throw std::runtime_error("RayAggregator: Ray capacity overrun! Use smaller bins");
+      if (print_overflow) {
+        std::cerr << "RayAggregator: Ray capacity overrun! Use smaller bins" << std::endl;
+        print_overflow = false;
+      }
+      return false;
+      //throw std::runtime_error("RayAggregator: Ray capacity overrun! Use smaller bins");
     }
     // insert point to ray, do some presorting
     ray.push_back(pt);


### PR DESCRIPTION
This PR updates the RayAggregator in the Ray Ground Classifier library such that a ray overflow simply disables continued processing of the current lidar scan rather than totally disabling the node. Since this overflow primarily occurs when localizing and has not been seen yet while the vehicle is driving it seems to be a safe change. Plus its better if object detection try to keep working instead of failing silently. 

Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1776

Some notes on implementation:
* ROS logging is not available in the library so iostream is used. This still appears on the output of the node
* To try to prevent logging per point a static variable is used such that it only prints once per ray of a scan. 