### PR TITLE
Fix Humble Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
         environment:
           TERM: xterm # use xterm to get full display output from build
           INIT_ENV: /home/carma/.base-image/init-env.sh
-          ROS_2_ENV: /opt/ros/foxy/setup.bash
+          ROS_2_ENV: /opt/ros/humble/setup.bash
     working_directory: "/opt/carma/"
     resource_class: large
     # Execution steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastoldev/carma-base:develop
+      - image: usdotfhwastoldev/carma-base:develop-humble
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Pull Deps
           command: |
             source ${INIT_ENV}
-            ./src/AutowareAuto/docker/checkout.bash -r ${PWD}
+            ./src/AutowareAuto/docker/checkout.bash -r ${PWD} -b develop-humble
       - run:
           name: Build Driver
           command: |

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -29,11 +29,11 @@ fi
 
 # Build 
 if [[ ! -z "$ROS2_PACKAGES" ]]; then
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-above $ROS2_PACKAGES
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-above $ROS2_PACKAGES --packages-ignore parking_planner parking_planner_nodes
 else
     # Install dependencies
     sudo apt-get update
     rosdep update
     rosdep install --from-paths src --ignore-src -r -y
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-ignore parking_planner parking_planner_nodes
 fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds a build argument to ignore the `parking_planner` and `parking_planner_nodes` packages when building. These packages are not needed and cannot currently be built in ROS 2 Humble.

## Related GitHub Issue

NA

## Related Jira Key

[ARC-160](https://usdot-carma.atlassian.net/browse/ARC-160)

## Motivation and Context

Needed for ROS2 Humble migration

## How Has This Been Tested?

In Progress

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[ARC-160]: https://usdot-carma.atlassian.net/browse/ARC-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ